### PR TITLE
Add unit tests for collision classes

### DIFF
--- a/tests/common/collision_bounding_box_tests.cpp
+++ b/tests/common/collision_bounding_box_tests.cpp
@@ -1,0 +1,113 @@
+#define CATCH_CONFIG_MAIN
+#include "../catch2/catch_amalgamated.hpp"
+#include <common/collision/culling/bounding_box.hpp>
+#include <common/math3d/plane.hpp>
+#include <glm/glm.hpp>
+#include <glm/ext.hpp>
+
+using namespace collision::culling;
+using namespace math3d;
+
+TEST_CASE("TrBoundingBox reConstruct method", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+  boundingBox.reConstruct(min, max, worldMatrix);
+
+  REQUIRE(boundingBox.minimum == min);
+  REQUIRE(boundingBox.maximum == max);
+  REQUIRE(boundingBox.center == glm::vec3(0.5f, 0.5f, 0.5f));
+  REQUIRE(boundingBox.extendSize == glm::vec3(0.5f, 0.5f, 0.5f));
+}
+
+TEST_CASE("TrBoundingBox scale method", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+  boundingBox.scale(2.0f);
+
+  REQUIRE(boundingBox.minimum == glm::vec3(-0.5f, -0.5f, -0.5f));
+  REQUIRE(boundingBox.maximum == glm::vec3(1.5f, 1.5f, 1.5f));
+  REQUIRE(boundingBox.center == glm::vec3(0.5f, 0.5f, 0.5f));
+  REQUIRE(boundingBox.extendSize == glm::vec3(1.0f, 1.0f, 1.0f));
+}
+
+TEST_CASE("TrBoundingBox isInFrustum method", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingBox.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingBox isCompletelyInFrustum method", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingBox.isCompletelyInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingBox isInFrustum method failure case", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingBox.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingBox isCompletelyInFrustum method failure case", "[TrBoundingBox]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingBox boundingBox(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingBox.isCompletelyInFrustum(frustumPlanes));
+}

--- a/tests/common/collision_bounding_info_tests.cpp
+++ b/tests/common/collision_bounding_info_tests.cpp
@@ -1,0 +1,112 @@
+#define CATCH_CONFIG_MAIN
+#include "../catch2/catch_amalgamated.hpp"
+#include <common/collision/culling/bounding_info.hpp>
+#include <common/math3d/plane.hpp>
+#include <glm/glm.hpp>
+#include <glm/ext.hpp>
+
+using namespace collision::culling;
+using namespace math3d;
+
+TEST_CASE("TrBoundingInfo reConstruct method", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+  boundingInfo.reConstruct(min, max, worldMatrix);
+
+  REQUIRE(boundingInfo.boundingBox.minimum == min);
+  REQUIRE(boundingInfo.boundingBox.maximum == max);
+  REQUIRE(boundingInfo.boundingSphere.minimum == min);
+  REQUIRE(boundingInfo.boundingSphere.maximum == max);
+}
+
+TEST_CASE("TrBoundingInfo update method", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+  glm::mat4 newWorldMatrix = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 1.0f, 1.0f));
+  boundingInfo.update(newWorldMatrix);
+
+  REQUIRE(boundingInfo.boundingBox.centerWorld == glm::vec3(1.5f, 1.5f, 1.5f));
+  REQUIRE(boundingInfo.boundingSphere.centerWorld == glm::vec3(1.5f, 1.5f, 1.5f));
+}
+
+TEST_CASE("TrBoundingInfo isInFrustum method", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingInfo.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingInfo isCompletelyInFrustum method", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingInfo.isCompletelyInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingInfo isInFrustum method failure case", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingInfo.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingInfo isCompletelyInFrustum method failure case", "[TrBoundingInfo]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingInfo boundingInfo(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingInfo.isCompletelyInFrustum(frustumPlanes));
+}

--- a/tests/common/collision_bounding_sphere_tests.cpp
+++ b/tests/common/collision_bounding_sphere_tests.cpp
@@ -1,0 +1,113 @@
+#define CATCH_CONFIG_MAIN
+#include "../catch2/catch_amalgamated.hpp"
+#include <common/collision/culling/bounding_sphere.hpp>
+#include <common/math3d/plane.hpp>
+#include <glm/glm.hpp>
+#include <glm/ext.hpp>
+
+using namespace collision::culling;
+using namespace math3d;
+
+TEST_CASE("TrBoundingSphere reConstruct method", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+  boundingSphere.reConstruct(min, max, worldMatrix);
+
+  REQUIRE(boundingSphere.minimum == min);
+  REQUIRE(boundingSphere.maximum == max);
+  REQUIRE(boundingSphere.center == glm::vec3(0.5f, 0.5f, 0.5f));
+  REQUIRE(boundingSphere.radius == Approx(0.866f).margin(0.001f));
+}
+
+TEST_CASE("TrBoundingSphere scale method", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+  boundingSphere.scale(2.0f);
+
+  REQUIRE(boundingSphere.minimum == glm::vec3(-0.5f, -0.5f, -0.5f));
+  REQUIRE(boundingSphere.maximum == glm::vec3(1.5f, 1.5f, 1.5f));
+  REQUIRE(boundingSphere.center == glm::vec3(0.5f, 0.5f, 0.5f));
+  REQUIRE(boundingSphere.radius == Approx(1.732f).margin(0.001f));
+}
+
+TEST_CASE("TrBoundingSphere isInFrustum method", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingSphere.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingSphere isCompletelyInFrustum method", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), 1.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), 1.0f)
+  };
+
+  REQUIRE(boundingSphere.isCompletelyInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingSphere isInFrustum method failure case", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingSphere.isInFrustum(frustumPlanes));
+}
+
+TEST_CASE("TrBoundingSphere isCompletelyInFrustum method failure case", "[TrBoundingSphere]") {
+  glm::vec3 min(0.0f, 0.0f, 0.0f);
+  glm::vec3 max(1.0f, 1.0f, 1.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+
+  TrBoundingSphere boundingSphere(min, max, worldMatrix);
+
+  std::array<TrPlane, 6> frustumPlanes = {
+    TrPlane(glm::vec3(1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(-1.0f, 0.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, -1.0f, 0.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, 1.0f), -2.0f),
+    TrPlane(glm::vec3(0.0f, 0.0f, -1.0f), -2.0f)
+  };
+
+  REQUIRE_FALSE(boundingSphere.isCompletelyInFrustum(frustumPlanes));
+}

--- a/tests/common/collision_ray_tests.cpp
+++ b/tests/common/collision_ray_tests.cpp
@@ -1,0 +1,95 @@
+#define CATCH_CONFIG_MAIN
+#include "../catch2/catch_amalgamated.hpp"
+#include <common/collision/ray.hpp>
+#include <common/collision/culling/bounding_box.hpp>
+#include <common/collision/culling/bounding_sphere.hpp>
+#include <glm/glm.hpp>
+#include <glm/ext.hpp>
+
+using namespace collision;
+using namespace collision::culling;
+
+TEST_CASE("TrRay intersectsBoxMinMax method", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(1.0f, 1.0f, 1.0f);
+  glm::vec3 max(2.0f, 2.0f, 2.0f);
+
+  REQUIRE(ray.intersectsBoxMinMax(min, max));
+}
+
+TEST_CASE("TrRay intersectsBox method", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(1.0f, 1.0f, 1.0f);
+  glm::vec3 max(2.0f, 2.0f, 2.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+  TrBoundingBox box(min, max, worldMatrix);
+
+  REQUIRE(ray.intersectsBox(box));
+}
+
+TEST_CASE("TrRay intersectsSphere method", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(1.0f, 1.0f, 1.0f);
+  glm::vec3 max(2.0f, 2.0f, 2.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+  TrBoundingSphere sphere(min, max, worldMatrix);
+
+  REQUIRE(ray.intersectsSphere(sphere, 0.0f));
+}
+
+TEST_CASE("TrRay update method", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray;
+  ray.update(origin, direction, 2.0f);
+
+  REQUIRE(ray.origin == origin);
+  REQUIRE(ray.direction == direction);
+  REQUIRE(ray.length == 2.0f);
+}
+
+TEST_CASE("TrRay intersectsBoxMinMax method failure case", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(2.0f, 2.0f, 2.0f);
+  glm::vec3 max(3.0f, 3.0f, 3.0f);
+
+  REQUIRE_FALSE(ray.intersectsBoxMinMax(min, max));
+}
+
+TEST_CASE("TrRay intersectsBox method failure case", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(2.0f, 2.0f, 2.0f);
+  glm::vec3 max(3.0f, 3.0f, 3.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+  TrBoundingBox box(min, max, worldMatrix);
+
+  REQUIRE_FALSE(ray.intersectsBox(box));
+}
+
+TEST_CASE("TrRay intersectsSphere method failure case", "[TrRay]") {
+  glm::vec3 origin(0.0f, 0.0f, 0.0f);
+  glm::vec3 direction(1.0f, 1.0f, 1.0f);
+  TrRay ray(origin, direction);
+
+  glm::vec3 min(2.0f, 2.0f, 2.0f);
+  glm::vec3 max(3.0f, 3.0f, 3.0f);
+  glm::mat4 worldMatrix = glm::mat4(1.0f);
+  TrBoundingSphere sphere(min, max, worldMatrix);
+
+  REQUIRE_FALSE(ray.intersectsSphere(sphere, 0.0f));
+}


### PR DESCRIPTION
Add unit tests for files under `src/common/collision`.

* **Bounding Box Tests**
  - Add `tests/common/collision_bounding_box_tests.cpp`.
  - Validate `reConstruct`, `scale`, `isInFrustum`, and `isCompletelyInFrustum` methods.
  - Add failure cases for `isInFrustum` and `isCompletelyInFrustum`.

* **Bounding Info Tests**
  - Add `tests/common/collision_bounding_info_tests.cpp`.
  - Validate `reConstruct`, `update`, `isInFrustum`, and `isCompletelyInFrustum` methods.
  - Add failure cases for `isInFrustum` and `isCompletelyInFrustum`.

* **Bounding Sphere Tests**
  - Add `tests/common/collision_bounding_sphere_tests.cpp`.
  - Validate `reConstruct`, `scale`, `isInFrustum`, and `isCompletelyInFrustum` methods.
  - Add failure cases for `isInFrustum` and `isCompletelyInFrustum`.

* **Ray Tests**
  - Add `tests/common/collision_ray_tests.cpp`.
  - Validate `intersectsBoxMinMax`, `intersectsBox`, `intersectsSphere`, and `update` methods.
  - Add failure cases for `intersectsBoxMinMax`, `intersectsBox`, and `intersectsSphere`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/M-CreativeLab/jsar-runtime/pull/29?shareId=4b9f92fa-6b96-41ff-9dc9-b6ec77a53224).