### PR TITLE
fix(layout): skip to create node under none layout

### DIFF
--- a/src/client/layout/layout_view.cpp
+++ b/src/client/layout/layout_view.cpp
@@ -202,15 +202,23 @@ namespace client_layout
                                                          shared_ptr<LayoutBlock> parentBlock,
                                                          shared_ptr<LayoutObject> beforeObject)
   {
-    // If the parent is a replaced element, don't create any children
-    if (parentBlock != nullptr && parentBlock->isLayoutReplaced())
-      return nullptr;
-
-    shared_ptr<LayoutBoxModelObject> boxObject = makeBox(displayStr, element);
-    if (parentBlock != nullptr)
-      parentBlock->addChild(boxObject, beforeObject);
-    else
+    shared_ptr<LayoutBoxModelObject> boxObject = nullptr;
+    if (parentBlock == nullptr)
+    {
+      // Add child to the view directly if no parent block is given.
+      boxObject = makeBox(displayStr, element);
       addChild(boxObject);
+    }
+    else
+    {
+      // Skip creating box if the parent is none or a replaced element
+      if (parentBlock->isNone() ||
+          parentBlock->isLayoutReplaced())
+        return nullptr;
+
+      boxObject = makeBox(displayStr, element);
+      parentBlock->addChild(boxObject, beforeObject);
+    }
 
     assert(boxObject->parent() != nullptr && "Inserted box must have a parent box.");
     boxObject->createEntity();
@@ -222,8 +230,9 @@ namespace client_layout
   {
     assert(parentBox != nullptr && "The parent box must be set for the text object.");
 
-    // If the parent is a replaced element, don't create text children
-    if (parentBox->isLayoutReplaced())
+    // If the parent is none or a replaced element, don't create text children
+    if (parentBox->isNone() ||
+        parentBox->isLayoutReplaced())
       return nullptr;
 
     shared_ptr<LayoutText> textObject = makeText(textNode);


### PR DESCRIPTION
This pull request updates the logic for adding child layout objects in `layout_view.cpp` to more robustly handle cases where the parent is either absent, set to "none", or is a replaced element. The changes ensure that layout objects and text nodes are only created and added to appropriate parents, preventing invalid layout tree structures.

**Improvements to layout child creation logic:**

* Updated the logic in `namespace client_layout` to skip creating box model children if the parent block is either "none" or a replaced element, and to add children directly to the view if no parent block is provided.
* Modified the text object creation to prevent adding text children when the parent box is either "none" or a replaced element, improving consistency and preventing invalid layout trees.