### PR TITLE
fix(renderer): make each unit has multiple texture bindings per target

### DIFF
--- a/src/renderer/gles/context_app.cpp
+++ b/src/renderer/gles/context_app.cpp
@@ -143,7 +143,10 @@ void ContextGLApp::onActiveTextureUnitChanged(int active_unit)
 
 void ContextGLApp::onTextureBindingChanged(GLenum target, GLuint texture)
 {
-  m_TextureBindings[m_LastActiveTextureUnit] = GLTextureBinding(target, texture);
+  auto it = m_TextureBindings.find(m_LastActiveTextureUnit);
+  if (it == m_TextureBindings.end())
+    m_TextureBindings.emplace(m_LastActiveTextureUnit, GLTextureUnitBinding());
+  m_TextureBindings[m_LastActiveTextureUnit].setBinding(target, texture);
 }
 
 void ContextGLApp::RecordProgramOnCreated(GLuint program)

--- a/src/renderer/gles/context_host.cpp
+++ b/src/renderer/gles/context_host.cpp
@@ -57,47 +57,45 @@ void ContextGLHost::recordFromHost()
   glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint *)&m_LastActiveTextureUnit);
 
   clearTextureBindings();
-  // FIXME(yorkie): currently only record from 0-31 texture units to avoid the performance issue, we can record more
+  // FIXME(yorkie): currently only record from 0-16 texture units to avoid the performance issue, we can record more
   // texture units if needed.
-  for (int unit = GL_TEXTURE0; unit <= GL_TEXTURE31; unit++)
+  for (int unit = GL_TEXTURE0; unit <= GL_TEXTURE16; unit++)
   {
     GLint texture = 0;
     glActiveTexture(unit);
+
+    // Ensure the texture unit object
+    m_TextureBindings.emplace(unit, GLTextureUnitBinding());
 
     // Reading the TEXTURE_2D
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture);
     if (texture > 0)
     {
-      m_TextureBindings[unit] = GLTextureBinding(GL_TEXTURE_2D, texture);
-      continue;
+      m_TextureBindings[unit].setBinding(GL_TEXTURE_2D, texture, true);
     }
 
     // Reading the TEXTURE_2D_ARRAY
     glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &texture);
     if (texture > 0)
     {
-      m_TextureBindings[unit] = GLTextureBinding(GL_TEXTURE_2D_ARRAY, texture);
-      continue;
+      m_TextureBindings[unit].setBinding(GL_TEXTURE_2D_ARRAY, texture, true);
     }
 
     // Reading the TEXTURE_3D
     glGetIntegerv(GL_TEXTURE_BINDING_3D, &texture);
     if (texture > 0)
     {
-      m_TextureBindings[unit] = GLTextureBinding(GL_TEXTURE_3D, texture);
-      continue;
+      m_TextureBindings[unit].setBinding(GL_TEXTURE_3D, texture, true);
     }
 
     // Reading the TEXTURE_CUBE_MAP
     glGetIntegerv(GL_TEXTURE_BINDING_CUBE_MAP, &texture);
     if (texture > 0)
     {
-      m_TextureBindings[unit] = GLTextureBinding(GL_TEXTURE_CUBE_MAP, texture);
-      continue;
+      m_TextureBindings[unit].setBinding(GL_TEXTURE_CUBE_MAP, texture, true);
     }
 
-    // TODO(yorkie): support other texture targets like GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_2D_MULTISAMPLE_ARRAY, etc.
-    m_TextureBindings[unit] = GLTextureBinding(GL_TEXTURE_2D, 0);
+    // TODO(yorkie): support more texture targets if needed.
   }
   glActiveTexture(m_LastActiveTextureUnit);
 

--- a/src/renderer/gles/context_storage.cpp
+++ b/src/renderer/gles/context_storage.cpp
@@ -256,8 +256,8 @@ void ContextGLStorage::restore()
   for (auto &it : m_TextureBindings)
   {
     GLenum unit = it.first;
-    GLTextureBinding &texture = it.second;
-    texture.bindTo(unit);
+    auto &textures = it.second;
+    textures.bindTo(unit);
   }
   glActiveTexture(m_LastActiveTextureUnit);
   bindTextureError = glGetError();

--- a/src/renderer/gles/context_storage.hpp
+++ b/src/renderer/gles/context_storage.hpp
@@ -35,6 +35,7 @@ private:
   std::string name_;
 };
 
+using GLTextureUnit = GLenum;
 class GLTextureBinding
 {
 public:
@@ -63,17 +64,106 @@ public:
     return texture_;
   }
 
+  inline void bind()
+  {
+    glBindTexture(target_, texture_);
+  }
+
   // Bind this texture to the specified texture unit.
   // The `unit` should be one of the GL_TEXTURE0, GL_TEXTURE1, ..., GL_TEXTURE31.
   inline void bindTo(GLenum unit)
   {
     glActiveTexture(unit);
-    glBindTexture(target_, texture_);
+    bind();
   }
 
 private:
   GLenum target_;
   GLuint texture_;
+};
+
+class GLTextureUnitBinding
+{
+public:
+  GLTextureUnitBinding()
+      : texture2d_binding_(std::nullopt)
+      , texture2d_array_binding_(std::nullopt)
+      , texture3d_binding_(std::nullopt)
+  {
+  }
+
+  void setBinding(GLenum target, GLuint texture, bool unbind = false)
+  {
+    bool recorded = false;
+    if (target == GL_TEXTURE_2D)
+    {
+      texture2d_binding_.emplace(target, texture);
+      recorded = true;
+    }
+    else if (target == GL_TEXTURE_2D_ARRAY)
+    {
+      texture2d_array_binding_.emplace(target, texture);
+      recorded = true;
+    }
+    else if (target == GL_TEXTURE_3D)
+    {
+      texture3d_binding_.emplace(target, texture);
+      recorded = true;
+    }
+    else if (target == GL_TEXTURE_CUBE_MAP)
+    {
+      texture_cube_map_binding_.emplace(target, texture);
+      recorded = true;
+    }
+    else
+    {
+      DEBUG(LOG_TAG_ERROR, "Unsupported texture target: %d", target);
+    }
+
+    // Unbind the texture after having recorded it to avoid the side effects for the next binding.
+    if (recorded && unbind)
+    {
+      glBindTexture(target, 0);
+    }
+  }
+
+  std::optional<GLTextureBinding> getBinding(GLenum target) const
+  {
+    if (target == GL_TEXTURE_2D)
+      return texture2d_binding_;
+    else if (target == GL_TEXTURE_2D_ARRAY)
+      return texture2d_array_binding_;
+    else if (target == GL_TEXTURE_3D)
+      return texture3d_binding_;
+    else if (target == GL_TEXTURE_CUBE_MAP)
+      return texture_cube_map_binding_;
+    else
+      DEBUG(LOG_TAG_ERROR, "Unsupported texture target: %d", target);
+    return std::nullopt;
+  }
+
+  void bindTo(GLenum unit)
+  {
+    glActiveTexture(unit);
+    texture2d_binding_.has_value()
+      ? texture2d_binding_->bind()
+      : glBindTexture(GL_TEXTURE_2D, 0);
+    texture2d_array_binding_.has_value()
+      ? texture2d_array_binding_->bind()
+      : glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+    texture3d_binding_.has_value()
+      ? texture3d_binding_->bind()
+      : glBindTexture(GL_TEXTURE_3D, 0);
+    texture_cube_map_binding_.has_value()
+      ? texture_cube_map_binding_->bind()
+      : glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+  }
+
+private:
+  std::optional<GLTextureBinding> texture2d_binding_;
+  std::optional<GLTextureBinding> texture2d_array_binding_;
+  std::optional<GLTextureBinding> texture3d_binding_;
+  std::optional<GLTextureBinding> texture_cube_map_binding_;
 };
 
 class OpenGLBlendingFunc
@@ -405,8 +495,8 @@ protected: /** OpenGLES objects */
   std::optional<GLuint> m_FramebufferId;
   std::optional<GLuint> m_RenderbufferId;
   GLint m_VertexArrayObjectId = 0;
-  GLenum m_LastActiveTextureUnit = GL_TEXTURE0;
-  std::unordered_map<GLenum, GLTextureBinding> m_TextureBindings;
+  GLTextureUnit m_LastActiveTextureUnit = GL_TEXTURE0;
+  std::unordered_map<GLTextureUnit, GLTextureUnitBinding> m_TextureBindings;
 };
 
 class OpenGLNamesStorage : public std::map<GLuint, bool>


### PR DESCRIPTION
This pull request refactors how texture bindings are managed in the OpenGL renderer codebase. The main change is introducing the new `GLTextureUnitBinding` class to handle multiple texture targets per texture unit, replacing the previous approach that stored only one binding per unit. This makes the texture binding logic more robust and extensible, and also updates the logic to only record up to 16 texture units for performance reasons.