### PR TITLE
feat(layout): integrate new version of taffy to support inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b01d27060ad58be4663b9e4ac9e2d4806918e8876af8912afbddd1a91d5eaa"
+checksum = "12101ecc8225ea6d675bc70263074eab6169079621c2186fe0c66590b2df9681"
 
 [[package]]
 name = "guillotiere"
@@ -2869,9 +2869,8 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaef0ac998e6527d6d0d5582f7e43953bb17221ac75bb8eb2fcc2db3396db1c"
+version = "0.9.0"
+source = "git+https://github.com/m-creativelab/taffy?branch=copilot%2Ffix-1#f67f2ee7701dd4d89126fd629abf7ba26ff14977"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ syn = { version = "2", default-features = false, features = [
   "derive",
   "parsing",
 ] }
-taffy = { version = "0.8.0" }
+taffy = { git = "https://github.com/m-creativelab/taffy", branch = "copilot/fix-1" }
 time = "0.1.41"
 url = "2.5"
 uuid = { version = "1.8.0", features = ["v4"] }

--- a/crates/jsbindings/bindings.layout.hpp
+++ b/crates/jsbindings/bindings.layout.hpp
@@ -154,6 +154,7 @@ namespace crates::layout2
     using OverflowXY = holocron::layout::OverflowXY;
 
 #define DISPLAY_MAP(XX) \
+  XX(Inline, "inline")  \
   XX(Block, "block")    \
   XX(Flex, "flex")      \
   XX(Grid, "grid")      \
@@ -210,6 +211,10 @@ namespace crates::layout2
       using CSSKeyword::CSSKeyword;
 
     public:
+      static Display Inline()
+      {
+        return Display(holocron::layout::Display::Inline);
+      }
       static Display Block()
       {
         return Display(holocron::layout::Display::Block);

--- a/crates/jsbindings/layout.rs
+++ b/crates/jsbindings/layout.rs
@@ -239,6 +239,7 @@ mod ffi {
   #[repr(u8)]
   #[derive(Clone, Copy, Debug)]
   enum Display {
+    Inline,
     Block,
     Flex,
     Grid,
@@ -643,7 +644,7 @@ impl From<taffy::Rect<f32>> for ffi::NumberRect {
   }
 }
 
-impl_type_casting_simple!(Display, { Block, Flex, Grid, None }, Block);
+impl_type_casting_simple!(Display, { Inline, Block, Flex, Grid, None }, Block);
 impl_type_casting_simple!(BoxSizing, { ContentBox, BorderBox }, ContentBox);
 impl_type_casting_simple!(Overflow, { Visible, Clip, Hidden, Scroll }, Visible);
 impl_type_casting_simple!(Position, { Relative, Absolute }, Relative);
@@ -1096,7 +1097,7 @@ fn max_track(input: &StyloSpecifiedValues::TrackBreadth) -> taffy::MaxTrackSizin
 }
 
 #[inline]
-fn track_size(input: &StyloSpecifiedValues::TrackSize) -> taffy::NonRepeatedTrackSizingFunction {
+fn track_size(input: &StyloSpecifiedValues::TrackSize) -> taffy::TrackSizingFunction {
   match input {
     StyloSpecifiedValues::TrackSize::Breadth(breadth) => taffy::MinMax {
       min: min_track(breadth),
@@ -1123,18 +1124,18 @@ fn track_size(input: &StyloSpecifiedValues::TrackSize) -> taffy::NonRepeatedTrac
 #[inline]
 fn track_repeat(
   count: &StyloGenericsValues::grid::RepeatCount<StyloSpecifiedValues::Integer>,
-) -> taffy::GridTrackRepetition {
+) -> taffy::RepetitionCount {
   match count {
     StyloGenericsValues::grid::RepeatCount::Number(v) => {
-      taffy::GridTrackRepetition::Count(v.value().try_into().unwrap())
+      taffy::RepetitionCount::Count(v.value().try_into().unwrap())
     }
-    StyloGenericsValues::grid::RepeatCount::AutoFill => taffy::GridTrackRepetition::AutoFill,
-    StyloGenericsValues::grid::RepeatCount::AutoFit => taffy::GridTrackRepetition::AutoFit,
+    StyloGenericsValues::grid::RepeatCount::AutoFill => taffy::RepetitionCount::AutoFill,
+    StyloGenericsValues::grid::RepeatCount::AutoFit => taffy::RepetitionCount::AutoFit,
   }
 }
 
 #[inline]
-fn grid_template_tracks(input_str: &str) -> Vec<taffy::TrackSizingFunction> {
+fn grid_template_tracks(input_str: &str) -> Vec<taffy::GridTemplateComponent<String>> {
   use style::values::generics::grid::GenericTrackListValue;
   use style::values::specified::GridTemplateComponent;
 
@@ -1148,12 +1149,19 @@ fn grid_template_tracks(input_str: &str) -> Vec<taffy::TrackSizingFunction> {
         .iter()
         .map(|track| match track {
           GenericTrackListValue::TrackSize(size) => {
-            taffy::TrackSizingFunction::Single(track_size(size))
+            taffy::GridTemplateComponent::Single(track_size(size))
           }
-          GenericTrackListValue::TrackRepeat(repeat) => taffy::TrackSizingFunction::Repeat(
-            track_repeat(&repeat.count),
-            repeat.track_sizes.iter().map(track_size).collect(),
-          ),
+          GenericTrackListValue::TrackRepeat(repeat) => {
+            taffy::GridTemplateComponent::Repeat(taffy::GridTemplateRepetition {
+              count: track_repeat(&repeat.count),
+              tracks: repeat
+                .track_sizes
+                .iter()
+                .map(track_size)
+                .collect::<Vec<_>>(),
+              line_names: vec![],
+            })
+          }
         })
         .collect(),
       GridTemplateComponent::Subgrid(_) => vec![],
@@ -1163,7 +1171,7 @@ fn grid_template_tracks(input_str: &str) -> Vec<taffy::TrackSizingFunction> {
 }
 
 #[inline]
-fn grid_auto_tracks(input_str: &str) -> Vec<taffy::NonRepeatedTrackSizingFunction> {
+fn grid_auto_tracks(input_str: &str) -> Vec<taffy::TrackSizingFunction> {
   crate::css_parser::CSSParser::default()
     .parse_grid_implicit_tracks(input_str)
     .map(|list| list.0.iter().map(track_size).collect())

--- a/fixtures/html/simple.html
+++ b/fixtures/html/simple.html
@@ -65,7 +65,7 @@
       line-height: 1.5;
     }
 
-    span.sub {
+    .sub {
       display: block;
       font-family: monospace;
       padding: 20px;
@@ -74,6 +74,12 @@
       font-weight: bold;
       font-size: 40px;
       transform: translate3d(0, 0, 0);
+    }
+
+    .sub a {
+      display: inline;
+      height: 200px;
+      width: 100px;
     }
 
     span.sub:hover {
@@ -98,7 +104,9 @@
 <body>
   <img class="float-image" src="https://www.gstatic.com/webp/gallery/1.webp" alt="A cute kitten">
   <div id="header">Hello World, JSAR 你好 😯</div>
-  <span id="switch" class="sub">inline text</span>
+  <span id="switch" class="sub">
+    <a></a><a></a>
+  </span>
   <img id="stereo-image" src="./images/sbs-example2.png" spatial="stereo">
   <main>
     <div style="position:absolute;left:50vw;width:50vw;height:100px;background-color:#9a9ec2; transform: translate3d(10vw, 0, 40px);">

--- a/src/client/cssom/values/specified/box.hpp
+++ b/src/client/cssom/values/specified/box.hpp
@@ -157,6 +157,18 @@ namespace client_cssom::values::specified
     {
       return isFlex() || isGrid();
     }
+    inline bool isFlow() const
+    {
+      return tag_ == kFlow || tag_ == kFlowRoot;
+    }
+    inline bool isFlowRoot() const
+    {
+      return tag_ == kFlowRoot;
+    }
+    inline bool isTable() const
+    {
+      return tag_ == kTable;
+    }
 
   private:
     Tag tag_;
@@ -262,7 +274,18 @@ namespace client_cssom::values::specified
   public:
     std::string toCss() const override
     {
-      return "display";
+      if (isNone())
+        return "none";
+      else if (isFlex())
+        return "flex";
+      else if (isGrid())
+        return "grid";
+      else if (isInline())
+        return "inline";
+      else if (isInlineBlock())
+        return "inline-block";
+      else
+        return "block";
     }
     Display toComputedValue(computed::Context &) const override
     {
@@ -276,6 +299,8 @@ namespace client_cssom::values::specified
         return crates::layout2::styles::Display::Flex();
       else if (isGrid())
         return crates::layout2::styles::Display::Grid();
+      else if (isInline())
+        return crates::layout2::styles::Display::Inline();
       else
         return crates::layout2::styles::Display::Block();
     }
@@ -304,6 +329,14 @@ namespace client_cssom::values::specified
     inline bool isGrid() const
     {
       return outside().isBlock() && inside().isGrid();
+    }
+    inline bool isInline() const
+    {
+      return outside().isInline() && inside().isFlow();
+    }
+    inline bool isInlineBlock() const
+    {
+      return outside().isInline() && inside().isFlowRoot();
     }
 
   private:

--- a/src/client/layout/formatting_contexts.cpp
+++ b/src/client/layout/formatting_contexts.cpp
@@ -56,6 +56,10 @@ namespace client_layout
       : FormattingContext(type, view)
       , node_(make_unique<crates::layout2::Node>(view->taffyNodeAllocatorRef()))
   {
+    // Update node style with the initial display type.
+    auto nodeStyle = node_->style();
+    nodeStyle.setDisplay(type);
+    updateNodeStyle(nodeStyle);
   }
 
   Fragment TaffyBasedFormattingContext::liveFragment() const


### PR DESCRIPTION
This pull request introduces support for the CSS `display: inline` property throughout the layout engine, updates the grid track parsing logic to match upstream `taffy` changes, and refines the corresponding test fixture to exercise the new behavior. The changes span updates to the Rust layout bindings, C++ CSSOM display logic, and the HTML fixture for testing. The most important changes are grouped below:
