### PR TITLE
fix(builtin_scene): bind vao when updating splat indexes buffer

### DIFF
--- a/src/client/builtin_scene/gaussian_splats_mesh.cpp
+++ b/src/client/builtin_scene/gaussian_splats_mesh.cpp
@@ -80,7 +80,7 @@ namespace builtin_scene
       bufferInitialized_ = true;
   }
 
-  void GaussianSplatsMesh::updateSplatBuffer(shared_ptr<WebGL2Context> glContext)
+  void GaussianSplatsMesh::updateSplatBuffer(shared_ptr<WebGL2Context> glContext, shared_ptr<WebGLVertexArray> vao)
   {
     if (!glContext ||
         !bufferInitialized_ ||
@@ -96,11 +96,14 @@ namespace builtin_scene
       indexData.push_back(splat.index);
 
     // Upload to GPU
-    glContext->bindBuffer(WebGLBufferBindingTarget::kArrayBuffer, splatInstanceBuffer_);
-    glContext->bufferData(WebGLBufferBindingTarget::kArrayBuffer,
-                          indexData.size() * sizeof(uint32_t),
-                          indexData.data(),
-                          WebGLBufferUsage::kDynamicDraw);
+    {
+      WebGLVertexArrayScope vaoScope(glContext, vao);
+      glContext->bindBuffer(WebGLBufferBindingTarget::kArrayBuffer, splatInstanceBuffer_);
+      glContext->bufferData(WebGLBufferBindingTarget::kArrayBuffer,
+                            indexData.size() * sizeof(uint32_t),
+                            indexData.data(),
+                            WebGLBufferUsage::kDynamicDraw);
+    }
     setDirty(false);
 
     DEBUG("GaussianSplatsMesh", "Updated GPU buffer with %zu sorted indices", sortedSplats_.size());

--- a/src/client/builtin_scene/gaussian_splats_mesh.hpp
+++ b/src/client/builtin_scene/gaussian_splats_mesh.hpp
@@ -185,7 +185,8 @@ namespace builtin_scene
      * Update the splat instance buffer with current splat indices.
      * This uploads only the sorted indices to GPU for rendering.
      */
-    void updateSplatBuffer(std::shared_ptr<client_graphics::WebGL2Context> glContext);
+    void updateSplatBuffer(std::shared_ptr<client_graphics::WebGL2Context> glContext,
+                           std::shared_ptr<client_graphics::WebGLVertexArray> vao);
 
     /**
      * Update the splat data textures with all splat properties.

--- a/src/client/builtin_scene/materials/gaussian_splatting.cpp
+++ b/src/client/builtin_scene/materials/gaussian_splatting.cpp
@@ -119,7 +119,7 @@ namespace builtin_scene::materials
         splatInstanceCount_ = splatsMesh->getTotalSplatCount();
 
         // Update buffer with sorted indices
-        splatsMesh->updateSplatBuffer(glContext);
+        splatsMesh->updateSplatBuffer(glContext, mesh->vertexArrayObject());
 
         // Bind compressed splat texture to texture unit 0
         auto compressedTexture = splatsMesh->getCompressedSplatsTexture();


### PR DESCRIPTION
This pull request updates the way splat instance buffers are managed and uploaded to the GPU in the Gaussian splatting rendering pipeline. The main change is the addition of vertex array object (VAO) management during buffer updates, which improves the safety and correctness of buffer uploads.

**Buffer and VAO management improvements:**

* The `updateSplatBuffer` method in `GaussianSplatsMesh` now requires a `WebGLVertexArray` parameter and uses a scoped VAO binding when uploading buffer data, ensuring the correct VAO is active during GPU operations.
* All calls to `updateSplatBuffer` are updated to pass the mesh's VAO, enforcing consistent VAO usage during buffer updates.