### PR TITLE
feat(cssom): expose the selectors text at style rule

### DIFF
--- a/crates/jsbindings/bindings.css.hpp
+++ b/crates/jsbindings/bindings.css.hpp
@@ -1198,6 +1198,7 @@ namespace crates::css2
     public:
       StyleRule(holocron::css::stylesheets::StyleRule &inner)
           : CssRule(CssRuleType::kStyle)
+          , selectorsText_(holocron::css::stylesheets::getStyleRuleSelectorsText(inner))
       {
         auto selectors = holocron::css::stylesheets::getStyleRuleSelectors(inner);
         selectors_ = std::make_unique<selectors::SelectorList>(*selectors);
@@ -1207,6 +1208,10 @@ namespace crates::css2
       }
 
     public:
+      const std::string &selectorsText() const
+      {
+        return selectorsText_;
+      }
       const selectors::SelectorList &selectors() const
       {
         return *selectors_;
@@ -1221,6 +1226,7 @@ namespace crates::css2
       }
 
     private:
+      std::string selectorsText_;
       std::unique_ptr<selectors::SelectorList> selectors_;
       std::unique_ptr<properties::PropertyDeclarationBlock> block_;
     };

--- a/crates/jsbindings/css/stylesheets/style_rule.rs
+++ b/crates/jsbindings/css/stylesheets/style_rule.rs
@@ -18,7 +18,7 @@ impl StyleRule {
   pub fn new(handle: &StyleRuleImpl, read_guard: &SharedRwLockReadGuard) -> Self {
     let block = handle.block.read_with(read_guard);
 
-    // convert handle.selectors to str
+    // Convert handle.selectors to CSS text string
     let mut selectors_text = String::new();
     handle
       .selectors

--- a/crates/jsbindings/css/stylesheets/style_rule.rs
+++ b/crates/jsbindings/css/stylesheets/style_rule.rs
@@ -1,17 +1,34 @@
+use std::borrow::Borrow;
+
 use crate::css::{properties::PropertyDeclarationBlock, selectors::SelectorList};
-use style::{shared_lock::SharedRwLockReadGuard, stylesheets::StyleRule as StyleRuleImpl};
+use cssparser::ToCss;
+use style::{
+  shared_lock::{SharedRwLockReadGuard, ToCssWithGuard},
+  stylesheets::StyleRule as StyleRuleImpl,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct StyleRule {
   pub selectors: SelectorList,
+  pub selectors_text: String,
   pub block: PropertyDeclarationBlock,
 }
 
 impl StyleRule {
   pub fn new(handle: &StyleRuleImpl, read_guard: &SharedRwLockReadGuard) -> Self {
     let block = handle.block.read_with(read_guard);
+
+    // convert handle.selectors to str
+    let mut selectors_text = String::new();
+    handle
+      .selectors
+      .borrow()
+      .to_css(&mut selectors_text)
+      .expect("Failed to convert selectors to CSS");
+ 
     Self {
       selectors: SelectorList::new(&handle.selectors),
+      selectors_text,
       block: PropertyDeclarationBlock::new(block),
     }
   }

--- a/crates/jsbindings/css_parser.rs
+++ b/crates/jsbindings/css_parser.rs
@@ -958,6 +958,9 @@ pub(crate) mod ffi {
     #[cxx_name = "getStyleRuleSelectors"]
     fn get_style_rule_selectors(rule: &CrateStyleRule) -> Box<PrismSelectorList>;
 
+    #[cxx_name = "getStyleRuleSelectorsText"]
+    fn get_style_rule_selectors_text(rule: &CrateStyleRule) -> String;
+
     /// Returns the property declaration block of the style rule.
     #[cxx_name = "getStyleRuleBlock"]
     fn get_style_rule_block(rule: &CrateStyleRule) -> Box<PropertyDeclarationBlock>;
@@ -1429,6 +1432,10 @@ fn get_media_rule_impl(rule: &CrateCssRule) -> Result<Box<CrateMediaRule>, Strin
 
 fn get_style_rule_selectors(rule: &CrateStyleRule) -> Box<PrismSelectorList> {
   Box::new(rule.selectors.clone())
+}
+
+fn get_style_rule_selectors_text(rule: &CrateStyleRule) -> String {
+  rule.selectors_text.clone()
 }
 
 fn get_style_rule_block(rule: &CrateStyleRule) -> Box<PropertyDeclarationBlock> {

--- a/src/client/cssom/rules/css_style_rule.hpp
+++ b/src/client/cssom/rules/css_style_rule.hpp
@@ -20,6 +20,7 @@ namespace client_cssom::rules
         , selectors_(inner.selectors())
         , style_(inner.takeBlock())
     {
+      // TODO(yorkie): use C++ css parser to parse from `inner.selectorsText()` instead of current parser from Rust.
     }
 
   public:


### PR DESCRIPTION
This pull request adds support for retrieving and exposing the raw CSS selector text for style rules in the bindings between Rust and C++. This enhancement allows consumers of the C++ API to access the original selector string as authored, which can be useful for debugging, serialization, or advanced CSSOM operations. The changes include updates to the Rust data model, FFI layer, and C++ bindings.
