### PR TITLE
fix(dom): handle inserting for DocumentFragment

### DIFF
--- a/src/client/dom/node.cpp
+++ b/src/client/dom/node.cpp
@@ -154,9 +154,29 @@ namespace dom
     auto it = find(childNodes.begin(), childNodes.end(), refChild);
     if (it != childNodes.end())
     {
-      childNodes.insert(it, newChild);
-      childAddedCallback(newChild);
-      return newChild;
+      if (Node::Is<DocumentFragment>(newChild))
+      {
+        // Append all the child nodes if the node is a `DocumentFragment`.
+        auto fragment = Node::As<DocumentFragment>(newChild);
+        for (auto child : fragment->childNodes)
+          insertBefore(child, refChild);
+        return newChild;
+      }
+      else if (Node::Is<Element>(newChild) ||
+               Node::Is<Text>(newChild) ||
+               Node::Is<Comment>(newChild))
+      {
+        childNodes.insert(it, newChild);
+        childAddedCallback(newChild);
+        return newChild;
+      }
+      else
+      {
+        string msg =
+          "Failed to insert the child: "
+          "the new child node is not a DocumentFragment, Text, Comment or Element.";
+        throw runtime_error(msg);
+      }
     }
     return nullptr;
   }


### PR DESCRIPTION
This pull request improves the robustness and standards compliance of the `insertBefore` method in the DOM implementation by adding explicit handling for different node types and error reporting. The main changes are focused on ensuring only valid node types are inserted and providing clear feedback when invalid nodes are encountered.

### DOM node insertion logic improvements

* Added support for inserting all child nodes of a `DocumentFragment` when passed as `newChild`, ensuring fragment nodes are properly handled in accordance with DOM specifications.
* Restricted insertion to only allow `Element`, `Text`, or `Comment` node types as valid children, preventing unsupported node types from being inserted.
* Introduced an explicit error message and exception when attempting to insert an invalid node type, improving error reporting and debugging.