### PR TITLE
Fix/web content depth writes

### DIFF
--- a/src/client/builtin_scene/instanced_mesh.cpp
+++ b/src/client/builtin_scene/instanced_mesh.cpp
@@ -654,17 +654,12 @@ namespace builtin_scene
 
     glContext_ = glContext;
     mesh3d_ = mesh3d;
-    depthOnlyInstances_ = make_shared<ContentInstancesList>(InstanceFilter::kTransparent,
-                                                            glContext->createVertexArray(),
-                                                            glContext->createBuffer());
   }
 
   void InstancedMeshBase::configureInstanceAttribs(shared_ptr<WebGLProgram> program, shared_ptr<Mesh3d> mesh3d)
   {
     auto glContext = glContext_.lock();
     assert(glContext != nullptr && "WebGL2 context must not be null.");
-    if (program != nullptr)
-      depthOnlyInstances_->configureAttribs(glContext, program, mesh3d);
   }
 
   void InstancedMeshBase::updateInstancesList(shared_ptr<client_graphics::WebGLProgram> program, bool ignoreDirty)
@@ -815,14 +810,7 @@ namespace builtin_scene
       }
     }
 
-    // 4. Update depth-only instances with all instances for use in `DepthOnlyPass`.
-    //
-    // Sorting is disabled for depth-only instances because the depth pass does not require front-to-back or
-    // back-to-front ordering. This improves performance, as sorting is unnecessary when only depth information is
-    // written and no blending occurs.
-    depthOnlyInstances_->update(idToInstanceMap_, ContentInstancesList::SortingOrder::kNone /* Disable sorting */);
-
-    // 5. Mark the structure as clean after updating.
+    // 4. Mark the structure as clean after updating.
     isStructureDirty_ = false;
   }
 }

--- a/src/client/builtin_scene/instanced_mesh.hpp
+++ b/src/client/builtin_scene/instanced_mesh.hpp
@@ -562,10 +562,6 @@ namespace builtin_scene
      */
     bool removeInstance(ecs::EntityId id);
 
-    inline ContentInstancesList &getDepthOnlyInstancesList() const
-    {
-      return *depthOnlyInstances_;
-    }
     inline size_t countLayers() const
     {
       return layeredInstances_.size();
@@ -637,7 +633,6 @@ namespace builtin_scene
     mutable std::shared_mutex mutex_;
     InstanceMap idToInstanceMap_;
     std::vector<LayeredInstancesData *> layeredInstances_; // Store pointers to active LayeredInstancesData objects
-    std::shared_ptr<ContentInstancesList> depthOnlyInstances_;
 
   private:
     std::weak_ptr<client_graphics::WebGL2Context> glContext_;

--- a/src/client/builtin_scene/materials/web_content_instanced.cpp
+++ b/src/client/builtin_scene/materials/web_content_instanced.cpp
@@ -162,15 +162,6 @@ namespace builtin_scene::materials
         glContext->stencilOp(WEBGL_KEEP, WEBGL_KEEP, WEBGL_REPLACE); // Replace stencil value on pass
         glContext->stencilMask(0xff);
 
-        if (inDepthWritePass)
-        {
-          glContext->depthMask(true);
-        }
-        else
-        {
-          glContext->depthMask(false);
-        }
-
         /**
          * Stencil masking format: [4 bits for container index | 4 bits for layer index]
          * 

--- a/src/client/builtin_scene/materials/web_content_instanced.cpp
+++ b/src/client/builtin_scene/materials/web_content_instanced.cpp
@@ -105,6 +105,8 @@ namespace builtin_scene::materials
     glm::mat4 matToUpdate = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, 0.001f));
     glContext->uniformMatrix4fv(loc.value(), false, matToUpdate);
 
+    bool inDepthWritePass = false;
+
     // b) Render layeredInstances_ in order (0-1-2-...)
     // First render scrollable container masks for each layer, then render regular content with stencil testing
     auto renderLayer = [&](RenderLayer layer, ContentInstancesList &layerInstancesList)
@@ -116,7 +118,19 @@ namespace builtin_scene::materials
       layerInstancesList.beforeInstancedDraw(*glContext, borderDataTexture);
       {
         // Draw layer instances to color attachment
-        glContext->depthMask(false);
+        if (inDepthWritePass)
+        {
+          // Depth write only pass, disable color writes and enable depth writes
+          glContext->colorMask(false, false, false, false);
+          glContext->depthMask(true);
+        }
+        else
+        {
+          // Normal pass, enable color writes and disable depth writes
+          glContext->colorMask(true, true, true, true);
+          glContext->depthMask(false);
+        }
+
         glContext->enable(WEBGL_BLEND);
         glContext->blendFunc(WEBGL_SRC_ALPHA, WEBGL_ONE_MINUS_SRC_ALPHA);
         glContext->drawElementsInstanced(mesh.primitiveTopology(),
@@ -147,6 +161,15 @@ namespace builtin_scene::materials
         glContext->colorMask(false, false, false, false);            // Don't write to color buffer for mask
         glContext->stencilOp(WEBGL_KEEP, WEBGL_KEEP, WEBGL_REPLACE); // Replace stencil value on pass
         glContext->stencilMask(0xff);
+
+        if (inDepthWritePass)
+        {
+          glContext->depthMask(true);
+        }
+        else
+        {
+          glContext->depthMask(false);
+        }
 
         /**
          * Stencil masking format: [4 bits for container index | 4 bits for layer index]
@@ -198,33 +221,23 @@ namespace builtin_scene::materials
       }
     };
 
+    // Iterate layers and render
+    inDepthWritePass = false;
     instancedMesh.iterateLayers(renderLayerWithMask);
 
     // d) Execute DepthOnlyPass once after all layers are rendered (if enabled)
     if (instancedMesh.isDepthOnlyPassEnabled())
     {
-      auto &depthOnlyInstancesList = instancedMesh.getDepthOnlyInstancesList();
-      if (depthOnlyInstancesList.count() > 0) [[likely]]
-      {
-        WebGLVertexArrayScope vaoScope(glContext, depthOnlyInstancesList.vao);
+      // Clear the stencil buffer for later use
+      glContext->clearStencil(0);
+      glContext->clear(WEBGL_STENCIL_BUFFER_BIT);
 
-        // Draw all instances to depth attachment only
-        depthOnlyInstancesList.beforeInstancedDraw(*glContext, nullptr);
-        {
-          glContext->colorMask(false, false, false, false);
-          glContext->depthMask(true);
-          glContext->disable(WEBGL_BLEND);
-          glContext->drawElementsInstanced(mesh.primitiveTopology(),
-                                           meshIndicesCount,
-                                           WEBGL_UNSIGNED_INT,
-                                           0,
-                                           depthOnlyInstancesList.count());
+      // Iterate layers and write depth
+      inDepthWritePass = true;
+      instancedMesh.iterateLayers(renderLayerWithMask);
 
-          // Restore the color mask state
-          glContext->colorMask(true, true, true, true);
-        }
-        depthOnlyInstancesList.afterInstancedDraw(*glContext);
-      }
+      // Reset the state
+      glContext->colorMask(true, true, true, true);
     }
   }
 


### PR DESCRIPTION
This pull request refactors how depth-only rendering is handled in the `web_content_instanced.cpp` material code. The main change is to unify the rendering logic for both normal and depth-only passes by using a shared layer iteration method, controlled by a new `inDepthWritePass` flag. This approach simplifies the code and ensures consistent state management across rendering passes.
