### PR TITLE
fix(browser): maintain only one instance for font manager

### DIFF
--- a/src/common/font/cache.hpp
+++ b/src/common/font/cache.hpp
@@ -279,6 +279,13 @@ namespace font
   class FontCacheManager
   {
   public:
+    static FontCacheManager *GetInstance()
+    {
+      static FontCacheManager *s_Instance = new FontCacheManager();
+      assert(s_Instance != nullptr && "Failed to create FontCacheManager instance");
+      return s_Instance;
+    }
+
     FontCacheManager()
         : fontMgr_(sk_make_sp<MutipleDirectoriesFontMgr>())
         , fontCollection_(sk_make_sp<skia::textlayout::FontCollection>())

--- a/src/examples/input_box.cpp
+++ b/src/examples/input_box.cpp
@@ -14,7 +14,11 @@ namespace jsar::example
       , isFocused_(false)
       , cursorPosition_(0)
       , lastCursorBlink_(0.0)
+      , canvas_(nullptr)
+      , fontMgr_(font::FontCacheManager::GetInstance())
   {
+    assert(fontMgr_ != nullptr);
+
     initGLProgram();
     resetCanvas();
 
@@ -24,6 +28,9 @@ namespace jsar::example
 
   InputBox::~InputBox()
   {
+    canvas_ = nullptr;
+    fontMgr_ = nullptr;
+
     glDeleteVertexArrays(1, &vao_);
     glDeleteBuffers(1, &vbo_);
     glDeleteProgram(program_);
@@ -142,7 +149,7 @@ namespace jsar::example
     cursorPaint_.setStyle(SkPaint::kFill_Style);
     cursorPaint_.setColor(0xFF007AFF); // Apple system blue for cursor
 
-    auto typeface = fontMgr_.getTypeface("monospace");
+    auto typeface = fontMgr_->getTypeface("monospace");
     textFont_.setTypeface(typeface);
     textFont_.setSize(14);
     textFont_.setEdging(SkFont::Edging::kSubpixelAntiAlias);

--- a/src/examples/input_box.hpp
+++ b/src/examples/input_box.hpp
@@ -99,7 +99,7 @@ namespace jsar::example
     SkPaint textPaint_;
     SkPaint cursorPaint_;
     SkFont textFont_;
-    font::FontCacheManager fontMgr_;
+    font::FontCacheManager *fontMgr_;
     SkImageInfo imageInfo_;
     std::vector<uint8_t> pixels_;
 

--- a/src/examples/screen_renderer.cpp
+++ b/src/examples/screen_renderer.cpp
@@ -4,12 +4,18 @@
 
 namespace jsar::example
 {
+  using namespace std;
+
   ScreenRenderer::ScreenRenderer(WindowContext *windowCtx)
       : windowCtx_(windowCtx)
   {
   }
 
   ScreenRenderer::~ScreenRenderer()
+  {
+  }
+
+  void ScreenRenderer::shutdown()
   {
     components_.clear();
   }

--- a/src/examples/screen_renderer.hpp
+++ b/src/examples/screen_renderer.hpp
@@ -47,6 +47,11 @@ namespace jsar::example
     ~ScreenRenderer();
 
     /**
+     * Shutdown the screen renderer and release resources.
+     */
+    void shutdown();
+
+    /**
      * Add a component to the screen renderer.
      */
     void addComponent(std::shared_ptr<ScreenComponent> component);

--- a/src/examples/stat_panel.hpp
+++ b/src/examples/stat_panel.hpp
@@ -51,6 +51,7 @@ namespace jsar::example
   public:
     StatPanel(WindowContext *windowCtx)
         : windowCtx(windowCtx)
+        , fontMgr(font::FontCacheManager::GetInstance())
     {
       initGLProgram();
       resetCanvas();
@@ -134,7 +135,7 @@ namespace jsar::example
       textPaint.setStyle(SkPaint::kFill_Style);
       textPaint.setColor(0xFF5b8c00);
 
-      auto typeface = fontMgr.getTypeface("monospace");
+      auto typeface = fontMgr->getTypeface("monospace");
       textFont.setTypeface(typeface);
       textFont.setSize(14);
       textFont.setEdging(SkFont::Edging::kSubpixelAntiAlias);
@@ -215,7 +216,7 @@ namespace jsar::example
     SkCanvas *canvas;
     SkPaint textPaint;
     SkFont textFont;
-    font::FontCacheManager fontMgr;
+    font::FontCacheManager *fontMgr;
 
     SkImageInfo imageInfo;
     std::vector<uint8_t> pixels;

--- a/src/examples/transmute_browser.cpp
+++ b/src/examples/transmute_browser.cpp
@@ -742,7 +742,9 @@ namespace jsar::example
         glBindFramebuffer(GL_FRAMEBUFFER, resolved_fbo_);
       glfwPollEvents();
     }
-    glfwTerminate();
+
+    // Shutdown window context firstly
+    windowCtx_->shutdown();
 
     // Shutdown the embedder when the window is closed.
     if (embedder_ != nullptr)
@@ -751,6 +753,10 @@ namespace jsar::example
     // Shutdown environment renderer
     if (envRenderer_ != nullptr)
       envRenderer_->shutdown();
+
+    // Shutdown screen renderer
+    if (screenRenderer_ != nullptr)
+      screenRenderer_->shutdown();
   }
 
   void TransmuteBrowser::renderContent()

--- a/src/examples/transmute_browser.hpp
+++ b/src/examples/transmute_browser.hpp
@@ -95,12 +95,12 @@ namespace jsar::example
 
     // Content management
     std::unordered_map<uint32_t, std::shared_ptr<Content>> contents_;
+    std::shared_ptr<BarComponent> contentsBarComponent_;
     uint32_t nextContentId_ = 1;
 
     // Screen GUI components
     std::shared_ptr<StatPanel> statPanel_;
     std::shared_ptr<InputBox> urlInputBox_;
-    std::shared_ptr<BarComponent> contentsBarComponent_;
 
     // Dragging state
     std::shared_ptr<Content> draggedContent_;

--- a/src/examples/window_ctx.cpp
+++ b/src/examples/window_ctx.cpp
@@ -88,6 +88,22 @@ namespace jsar::example
     initWindow(nullptr);
   }
 
+  void WindowContext::shutdown()
+  {
+    if (terminated)
+      return;
+
+    glfwSetCursorPosCallback(window, nullptr);
+    glfwSetScrollCallback(window, nullptr);
+    glfwSetMouseButtonCallback(window, nullptr);
+    glfwSetKeyCallback(window, nullptr);
+    glfwSetCharCallback(window, nullptr);
+    glfwTerminate();
+
+    terminated = true;
+    window = nullptr;
+  }
+
   TrViewport WindowContext::drawingViewport()
   {
     return TrViewport(width * contentScaling[0], height * contentScaling[1]);
@@ -422,12 +438,6 @@ namespace jsar::example
         currentViewerPosition = xrRenderer->viewerPosition();
       }
     }
-  }
-
-  void WindowContext::terminate()
-  {
-    glfwTerminate();
-    terminated = true;
   }
 
   void WindowContext::initWindow(GLFWmonitor *monitor)

--- a/src/examples/window_ctx.hpp
+++ b/src/examples/window_ctx.hpp
@@ -33,6 +33,7 @@ namespace jsar::example
     WindowContext(int width, int height);
 
   public:
+    void shutdown();
     bool isTerminated()
     {
       return terminated;
@@ -55,7 +56,6 @@ namespace jsar::example
     void setUIMouseButtonHandler(std::function<void(int, int, double, double)> handler);
 
   private:
-    void terminate();
     void initWindow(GLFWmonitor *monitor = nullptr);
 
   public:


### PR DESCRIPTION
This pull request introduces improvements to resource management and singleton usage in the font cache, as well as refactors for more robust shutdown procedures across GUI components. The most notable changes are the introduction of a singleton pattern for `FontCacheManager`, updates to ensure proper shutdown and cleanup of resources in window and screen rendering components, and adjustments to how font managers are referenced and used in UI classes.

**Font Cache and Resource Management**
* Implemented a singleton pattern for `FontCacheManager` via the new static `GetInstance()` method, ensuring a single shared instance throughout the application.
* Updated `InputBox` and `StatPanel` classes to use a pointer to the singleton `FontCacheManager` instead of holding their own instances, and adjusted font usage accordingly. [[1]](diffhunk://#diff-9406e76d4842d7cc9070fe8b852e7295f61748ecb4be7a5665c95bf9465516f0R17-R21) [[2]](diffhunk://#diff-bfa10ba0b50e6771947c51933badcca1d8b5904fb6ca32e96359544269c098d7L102-R102) [[3]](diffhunk://#diff-6c436409f70cf4d8c3802b69a4021d26a6a8d49f473c14c120bfbee024223579R54) [[4]](diffhunk://#diff-6c436409f70cf4d8c3802b69a4021d26a6a8d49f473c14c120bfbee024223579L218-R219)

**Shutdown and Cleanup Procedures**
* Added a `shutdown()` method to `WindowContext` that properly releases GLFW resources and resets window state, replacing the previous `terminate()` method. [[1]](diffhunk://#diff-388aee4f317e6a70f6d03d2c69214e5979d9dda43ce06b408ded7579c9d83445R91-R106) [[2]](diffhunk://#diff-bc33c9e01bcc20e7286870416be4c6f22f6d36ef111b08d08d3b872c84c4b291R36) [[3]](diffhunk://#diff-bc33c9e01bcc20e7286870416be4c6f22f6d36ef111b08d08d3b872c84c4b291L58) [[4]](diffhunk://#diff-388aee4f317e6a70f6d03d2c69214e5979d9dda43ce06b408ded7579c9d83445L427-L432)
* Introduced a `shutdown()` method for `ScreenRenderer` to facilitate explicit cleanup of rendering components. [[1]](diffhunk://#diff-3f45408d4a151a64037787c7227bf0f9bc0fe7944f08a60b2f63fee0a5ebd7ecR7-R18) [[2]](diffhunk://#diff-130d1f61386eb907c2f25607bc9b28379e07e3dcb5ffd1d78cec98c5d8d8ae62R49-R53)
* Updated `TransmuteBrowser` to call `shutdown()` on `windowCtx_`, `envRenderer_`, and `screenRenderer_` for orderly resource deallocation when the window is closed. [[1]](diffhunk://#diff-eaf7523c2983894a3ef54565a4135771373a301b15ec4a9431317d5970027a90L745-R747) [[2]](diffhunk://#diff-eaf7523c2983894a3ef54565a4135771373a301b15ec4a9431317d5970027a90R756-R759)

**Minor Refactors**
* Corrected member initialization order and usage for font managers and canvas pointers in UI components, and ensured proper cleanup in destructors. [[1]](diffhunk://#diff-9406e76d4842d7cc9070fe8b852e7295f61748ecb4be7a5665c95bf9465516f0R31-R33) [[2]](diffhunk://#diff-6c436409f70cf4d8c3802b69a4021d26a6a8d49f473c14c120bfbee024223579L137-R138)

**Content Bar Component Declaration**
* Moved the declaration of `contentsBarComponent_` in `TransmuteBrowser` to ensure proper member ordering and initialization.