### PR TITLE
fix(dep): upgrade glsl-lang to fix the glsl preprocessing issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -84,9 +84,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
@@ -148,18 +148,18 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -198,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -420,12 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,32 +600,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "unicode-xid",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -634,6 +616,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -644,27 +627,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -757,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -872,17 +834,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -890,7 +841,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -915,9 +866,8 @@ dependencies = [
 
 [[package]]
 name = "glsl-lang"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba2cedf511d6caa4957bc875b30f00bc06f6c8a82bd63dba6fe0caff432ab65"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
  "glsl-lang-lexer",
  "glsl-lang-types",
@@ -930,9 +880,8 @@ dependencies = [
 
 [[package]]
 name = "glsl-lang-lexer"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969d5a8a00546e91c4545dce3e4746c43957ca76d793b232d17b2617e87c6ada"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
  "glsl-lang-pp",
  "glsl-lang-types",
@@ -943,15 +892,14 @@ dependencies = [
 
 [[package]]
 name = "glsl-lang-pp"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47a3e9273bf24cdc3b79b83ffbcd670198c460eb267573708810b05621660a8"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
  "arrayvec",
  "bimap",
  "cbitset",
- "derive_more 1.0.0",
- "itertools 0.13.0",
+ "derive_more",
+ "itertools",
  "lang-util",
  "once_cell",
  "rowan",
@@ -963,9 +911,8 @@ dependencies = [
 
 [[package]]
 name = "glsl-lang-types"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b499cdb44bfebb9a8565ebdc9f72a77f1e2d18951d8b1f0a003b85ab4604ab1"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
  "lang-util",
  "thiserror 2.0.12",
@@ -1275,24 +1222,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1374,6 +1303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,42 +1319,42 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools 0.11.0",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
  "regex-syntax",
+ "sha3",
  "string_cache",
  "term",
- "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
  "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
 name = "lang-util"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56696a120465502161fe2c62cd784ee4a338f2460019339a504a0862ab31475a"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
- "derive_more 1.0.0",
+ "derive_more",
  "lalrpop-util",
  "lang-util-derive",
  "line-span",
@@ -1426,9 +1364,8 @@ dependencies = [
 
 [[package]]
 name = "lang-util-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77522b4885ddae41b7c4134a2c33e22a7b09be0bd4c4ce1bee125a372f2f6984"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1478,16 +1415,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
-]
 
 [[package]]
 name = "line-span"
@@ -1786,9 +1713,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1989,17 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,9 +1946,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rowan"
-version = "0.15.16"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
@@ -2104,7 +2020,7 @@ source = "git+https://github.com/m-creativelab/stylo?branch=2025-06-03-jsar-2025
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
- "derive_more 2.0.1",
+ "derive_more",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -2183,6 +2099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,10 +2160,11 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
+ "borsh",
  "serde",
 ]
 
@@ -2338,13 +2265,13 @@ dependencies = [
  "bitflags 2.9.1",
  "byteorder",
  "cssparser",
- "derive_more 2.0.1",
+ "derive_more",
  "encoding_rs",
  "euclid",
  "fxhash",
  "icu_segmenter",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "itoa",
  "lazy_static",
  "log",
@@ -2887,13 +2814,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "a43bddab41f8626c7bdaab872bbba75f8df5847b516d77c569c746e2ae5eb746"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2972,15 +2897,6 @@ name = "time-point"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "tinystr"
@@ -3185,12 +3101,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3639,3 +3549,18 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[patch.unused]]
+name = "glsl-lang-cli"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
+
+[[patch.unused]]
+name = "glsl-lang-quote"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"
+
+[[patch.unused]]
+name = "lang-util-dev"
+version = "0.8.0"
+source = "git+https://github.com/jsar-project/glsl-lang?branch=20250904#34c69816797b33fecf9a3a0dc2bf1a084850b0eb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ euclid = "0.22"
 fnv = "1.0"
 getopts = "0.2.11"
 gleam = "0.15"
-glsl-lang = { version = "0.7.2", features = ["lexer-v2-full"] }
-glsl-lang-pp = { version = "0.7.2", features = ["full"] }
+glsl-lang = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904", features = ["lexer-full"] }
+glsl-lang-pp = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904", features = ["full"] }
 headers = "0.3"
 hyper = "0.14"
 hyper-rustls = { version = "0.24", default-features = false, features = [
@@ -67,3 +67,15 @@ taffy = { version = "0.8.0" }
 time = "0.1.41"
 url = "2.5"
 uuid = { version = "1.8.0", features = ["v4"] }
+
+# Patch to use the forked glsl-lang repository.
+[patch.crates-io]
+glsl-lang       = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+glsl-lang-pp    = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+glsl-lang-lexer = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+glsl-lang-types = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+glsl-lang-quote = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+glsl-lang-cli   = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+lang-util        = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+lang-util-derive = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }
+lang-util-dev    = { git = "https://github.com/jsar-project/glsl-lang", branch = "20250904" }

--- a/crates/jsbindings/webgl.rs
+++ b/crates/jsbindings/webgl.rs
@@ -64,7 +64,7 @@ impl VisitorMut for MyGLSLPatcher {
 
 fn patch_glsl_source_from_str(s: &str) -> String {
   use glsl_lang::{
-    ast::TranslationUnit, lexer::v2_full::fs::PreprocessorExt, parse::IntoParseBuilderExt,
+    ast::TranslationUnit, lexer::full::fs::PreprocessorExt, parse::IntoParseBuilderExt,
   };
 
   let mut processor = glsl_lang_pp::processor::fs::StdProcessor::new();


### PR DESCRIPTION
This pull request updates the GLSL-related dependencies to use a forked version from a specific GitHub repository, and makes corresponding code changes to ensure compatibility. The most important changes are focused on dependency management and code updates for the GLSL parser.

**Dependency management changes:**

* Updated the `glsl-lang` and `glsl-lang-pp` dependencies in `Cargo.toml` to use the forked repository at `https://github.com/jsar-project/glsl-lang` on branch `20250904`, and switched the feature from `lexer-v2-full` to `lexer-full`.
* Added a `[patch.crates-io]` section in `Cargo.toml` to redirect all GLSL-related crates (including `glsl-lang`, `glsl-lang-pp`, `glsl-lang-lexer`, `glsl-lang-types`, etc.) to the same forked repository and branch, ensuring consistency across all GLSL components.

**Code compatibility update:**

* Updated the import in `crates/jsbindings/webgl.rs` to use `lexer::full::fs::PreprocessorExt` instead of `lexer::v2_full::fs::PreprocessorExt`, reflecting the changes in the forked dependency.