### PR TITLE
fix(builtin_scene): use std::async to make each web content rendering…

### DIFF
--- a/src/client/builtin_scene/web_content_renderer.cpp
+++ b/src/client/builtin_scene/web_content_renderer.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <algorithm>
 #include <cstring>
+#include <future>
 
 #include <skia/include/core/SkCanvas.h>
 #include <skia/include/core/SkPaint.h>
@@ -331,13 +332,28 @@ namespace builtin_scene::web_renderer
     if (list.size() == 0)
       return;
 
+    vector<future<void>> futures;
+    futures.reserve(list.size());
+
+    // Lambda to render a single WebContent entity
+    auto renderContent = [this](ecs::EntityId entity, WebContent &content)
+    {
+      if (render(entity, content))
+        content.setSurfaceDirty(true);
+    };
+
+    // Schedule rendering tasks for each dirty WebContent entity
     for (auto &item : list)
     {
       ecs::EntityId entity = item.first;
       WebContent &content = *item.second;
-      if (render(entity, content))
-        content.setSurfaceDirty(true);
+      futures.emplace_back(async(launch::async, [&renderContent, entity, &content]()
+                                 { renderContent(entity, content); }));
     }
+
+    // Wait for all rendering tasks to complete
+    for (auto &future : futures)
+      future.wait();
   }
 
   // Create a gradient shader based on the computed image and rounded rectangle.


### PR DESCRIPTION
This pull request introduces parallel rendering for dirty `WebContent` entities in the `builtin_scene::web_renderer` namespace. By leveraging asynchronous tasks, the renderer can now process multiple web content surfaces concurrently, which should improve performance when dealing with many dirty entities.

**Performance improvements (parallel rendering):**

* Added `#include <future>` to enable asynchronous task execution in `web_content_renderer.cpp`.
* Refactored the rendering loop to launch an asynchronous task for each dirty `WebContent` entity using `std::async`, and then wait for all tasks to complete, allowing for parallel processing of rendering work.