### PR TITLE
fix(layout): use array instead of a merged bounding box to fix issue

### DIFF
--- a/fixtures/html/simple.html
+++ b/fixtures/html/simple.html
@@ -60,7 +60,7 @@
     }
 
     main:hover {
-      background-color: rgba(224, 172, 150, 0.352);
+      background-color: rgba(150, 156, 224, 0.352);
     }
 
     article {

--- a/src/client/dom/document_event_dispatcher.cpp
+++ b/src/client/dom/document_event_dispatcher.cpp
@@ -106,8 +106,6 @@ namespace dom
         auto hitPoint = result.hitPoint();
         target->simulateMouseUp(hitPoint);
 
-        cout << "Debug: Mouse up on element: " << target->nodeName << endl;
-
         if (is_click_in_progress_ &&
             // Criteria 1: same target
             current_mousedown_target_.lock() == target &&

--- a/src/client/dom/document_event_dispatcher.cpp
+++ b/src/client/dom/document_event_dispatcher.cpp
@@ -106,6 +106,8 @@ namespace dom
         auto hitPoint = result.hitPoint();
         target->simulateMouseUp(hitPoint);
 
+        cout << "Debug: Mouse up on element: " << target->nodeName << endl;
+
         if (is_click_in_progress_ &&
             // Criteria 1: same target
             current_mousedown_target_.lock() == target &&

--- a/src/client/layout/layout_box.cpp
+++ b/src/client/layout/layout_box.cpp
@@ -12,7 +12,6 @@ namespace client_layout
 
   LayoutBox::LayoutBox(shared_ptr<dom::Node> node)
       : LayoutBoxModelObject(node)
-      , hit_testable_bounding_box_{glm::vec3(0.0f), glm::vec3(0.0f), glm::mat4(1.0f)}
   {
   }
 
@@ -287,21 +286,30 @@ namespace client_layout
 
   bool LayoutBox::mayIntersect(const HitTestResult &r, const HitTestRay &ray, const glm::vec3 &accumulatedOffset) const
   {
-    optional<geometry::BoundingBox> overflowBox = nullopt;
+    vector<geometry::BoundingBox> overflowBoxes;
     if (hasHitTestableOverflow())
     {
       // TODO(yorkie): handle the hit test for the box with overflow.
     }
     else
-      overflowBox = getHitTestableBoundingBox();
+      overflowBoxes = getHitTestableBoundingBoxes();
 
-    if (overflowBox.has_value())
+    if (overflowBoxes.size() > 0)
     {
-      overflowBox->move(accumulatedOffset);
+      bool intersects = false;
+      for (auto box : overflowBoxes)
+      {
+        box.move(accumulatedOffset);
 
-      auto min = overflowBox->minimumWorld;
-      auto max = overflowBox->maximumWorld;
-      return ray.intersectsBoxMinMax(min, max);
+        auto min = box.minimumWorld;
+        auto max = box.maximumWorld;
+        if (ray.intersectsBoxMinMax(min, max))
+        {
+          intersects = true;
+          break;
+        }
+      }
+      return intersects;
     }
     else
     {
@@ -329,6 +337,14 @@ namespace client_layout
     return false;
   }
 
+  void LayoutBox::didComputeLayout(const ConstraintSpace &availableSpace)
+  {
+    LayoutBoxModelObject::didComputeLayout(availableSpace);
+
+    // Update the hit-testable bounding box.
+    updateHitTestableBoundingBoxes();
+  }
+
   void LayoutBox::didComputeLayoutOnce(const ConstraintSpace &availableSpace)
   {
     LayoutBoxModelObject::didComputeLayoutOnce(availableSpace);
@@ -340,9 +356,6 @@ namespace client_layout
       getScrollableArea()
         ->updateAfterLayout(formattingContext().liveFragment());
     }
-
-    // Update the hit-testable bounding box.
-    updateHitTestableBoundingBox();
   }
 
   void LayoutBox::updateFromStyle()
@@ -398,31 +411,44 @@ namespace client_layout
     return childBoxes;
   }
 
-  void LayoutBox::updateHitTestableBoundingBox()
+  void LayoutBox::updateHitTestableBoundingBoxes()
   {
-    auto selfBoundingBox = physicalBorderBoxRect();
-    glm::vec3 unionMin = selfBoundingBox.minimumWorld;
-    glm::vec3 unionMax = selfBoundingBox.maximumWorld;
+    hit_testable_bounding_boxes_.clear();
+
+    geometry::BoundingBox mainBoundingBox = physicalBorderBoxRect();
+    hit_testable_bounding_boxes_.push_back(mainBoundingBox);
+
+    glm::vec3 mainMin = mainBoundingBox.minimumWorld;
+    glm::vec3 mainMax = mainBoundingBox.maximumWorld;
 
     for (const auto &childBox : getChildBoxes())
     {
       if (!childBox->visible())
         continue;
 
-      const geometry::BoundingBox &childBoundingBox = childBox->getHitTestableBoundingBox();
-      unionMin.x = min(unionMin.x, childBoundingBox.minimumWorld.x);
-      unionMin.y = min(unionMin.y, childBoundingBox.minimumWorld.y);
-      unionMin.z = min(unionMin.z, childBoundingBox.minimumWorld.z);
-      unionMax.x = max(unionMax.x, childBoundingBox.maximumWorld.x);
-      unionMax.y = max(unionMax.y, childBoundingBox.maximumWorld.y);
-      unionMax.z = max(unionMax.z, childBoundingBox.maximumWorld.z);
-    }
-    hit_testable_bounding_box_ = geometry::BoundingBox(unionMin, unionMax, glm::mat4(1.0f));
+      const vector<geometry::BoundingBox> childBoundingBoxes = childBox->getHitTestableBoundingBoxes();
+      for (const auto &childBoundingBox : childBox->getHitTestableBoundingBoxes())
+      {
+        // Skip extending if the child box has no size.
+        if (glm::all(glm::epsilonEqual(childBoundingBox.extendSizeWorld,
+                                       glm::vec3(0.0f),
+                                       glm::epsilon<float>())))
+        {
+          continue;
+        }
 
-    // Notify the parent box to update its hit-testable bounding box.
-    if (parent() && parent()->isBox())
-    {
-      parentBox()->updateHitTestableBoundingBox();
+        // Check if the child box is fully contained in the main bounding box.
+        glm::vec3 childMin = childBoundingBox.minimumWorld;
+        glm::vec3 childMax = childBoundingBox.maximumWorld;
+        if (childMin.x >= mainMin.x && childMin.y >= mainMin.y && childMin.z >= mainMin.z &&
+            childMax.x <= mainMax.x && childMax.y <= mainMax.y && childMax.z <= mainMax.z)
+        {
+          continue; // Child box is fully contained, skip adding it.
+        }
+        hit_testable_bounding_boxes_.push_back(childBoundingBox);
+      }
     }
+
+    assert(hit_testable_bounding_boxes_.size() > 0);
   }
 }

--- a/src/client/layout/layout_box.cpp
+++ b/src/client/layout/layout_box.cpp
@@ -426,7 +426,6 @@ namespace client_layout
       if (!childBox->visible())
         continue;
 
-      const vector<geometry::BoundingBox> childBoundingBoxes = childBox->getHitTestableBoundingBoxes();
       for (const auto &childBoundingBox : childBox->getHitTestableBoundingBoxes())
       {
         // Skip extending if the child box has no size.

--- a/src/client/layout/layout_box.hpp
+++ b/src/client/layout/layout_box.hpp
@@ -214,7 +214,7 @@ namespace client_layout
     {
       return overflow_ != nullptr && overflow_->visualOverflow;
     }
-    inline const std::vector<geometry::BoundingBox>& getHitTestableBoundingBoxes() const
+    inline const std::vector<geometry::BoundingBox> &getHitTestableBoundingBoxes() const
     {
       return hit_testable_bounding_boxes_;
     }

--- a/src/client/layout/layout_box.hpp
+++ b/src/client/layout/layout_box.hpp
@@ -198,6 +198,7 @@ namespace client_layout
 
   protected:
     virtual bool hitTestChildren(HitTestResult &, const HitTestRay &, const glm::vec3 &accumulatedOffset, HitTestPhase);
+    virtual void didComputeLayout(const ConstraintSpace &) override;
     virtual void didComputeLayoutOnce(const ConstraintSpace &) override;
 
     void updateFromStyle() override;
@@ -213,11 +214,11 @@ namespace client_layout
     {
       return overflow_ != nullptr && overflow_->visualOverflow;
     }
-    inline geometry::BoundingBox getHitTestableBoundingBox() const
+    inline const std::vector<geometry::BoundingBox>& getHitTestableBoundingBoxes() const
     {
-      return hit_testable_bounding_box_;
+      return hit_testable_bounding_boxes_;
     }
-    void updateHitTestableBoundingBox();
+    void updateHitTestableBoundingBoxes();
 
     glm::vec3 computeSize() const;
     vector<std::shared_ptr<LayoutBox>> getChildBoxes() const;
@@ -229,6 +230,6 @@ namespace client_layout
 
   private:
     std::shared_ptr<BoxOverflowModel> overflow_;
-    geometry::BoundingBox hit_testable_bounding_box_;
+    std::vector<geometry::BoundingBox> hit_testable_bounding_boxes_;
   };
 }

--- a/src/client/layout/layout_object.cpp
+++ b/src/client/layout/layout_object.cpp
@@ -949,15 +949,15 @@ namespace client_layout
     }
   }
 
-  void LayoutObject::willComputeLayout(const ConstraintSpace &avilableSpace)
+  void LayoutObject::willComputeLayout(const ConstraintSpace &availableSpace)
   {
   }
 
-  void LayoutObject::didComputeLayout(const ConstraintSpace &avilableSpace)
+  void LayoutObject::didComputeLayout(const ConstraintSpace &availableSpace)
   {
   }
 
-  void LayoutObject::didComputeLayoutOnce(const ConstraintSpace &avilableSpace)
+  void LayoutObject::didComputeLayoutOnce(const ConstraintSpace &availableSpace)
   {
     if (hasSceneComponent<WebContent>())
     {

--- a/src/client/layout/layout_object.cpp
+++ b/src/client/layout/layout_object.cpp
@@ -953,6 +953,10 @@ namespace client_layout
   {
   }
 
+  void LayoutObject::didComputeLayout(const ConstraintSpace &avilableSpace)
+  {
+  }
+
   void LayoutObject::didComputeLayoutOnce(const ConstraintSpace &avilableSpace)
   {
     if (hasSceneComponent<WebContent>())

--- a/src/client/layout/layout_object.hpp
+++ b/src/client/layout/layout_object.hpp
@@ -456,6 +456,7 @@ namespace client_layout
     virtual void sizeDidChange(const Fragment &);
 
     virtual void willComputeLayout(const ConstraintSpace &);
+    virtual void didComputeLayout(const ConstraintSpace &);
     virtual void didComputeLayoutOnce(const ConstraintSpace &);
 
   private:

--- a/src/client/layout/layout_view.cpp
+++ b/src/client/layout/layout_view.cpp
@@ -55,7 +55,9 @@ namespace client_layout
     {
       if (object.isNone())
         return;
-      object.didComputeLayoutOnce(parent.fragment());
+
+      const auto &space = parent.fragment();
+      object.didComputeLayoutOnce(space);
 
       // traverse the children of the block or inline object.
       if (object.isLayoutBlock())
@@ -70,6 +72,9 @@ namespace client_layout
         for (shared_ptr<LayoutObject> child : inlineObject->childrenRef())
           traverseChildNode(*child, *inlineObject); // Just traverse the inline's children but don't compute layout.
       }
+
+      // Finally, call `didComputeLayout` for the object itself.
+      object.didComputeLayout(space);
     };
 
     // TODO(yorkie): support the lifecycle `willComputeLayout`?
@@ -84,6 +89,8 @@ namespace client_layout
     for (shared_ptr<LayoutObject> child : childrenRef())
       traverseChildNode(*child, *this);
 
+    // Finally, call `didComputeLayout` for the view itself.
+    didComputeLayout(avilableSpace);
     return r;
   }
 

--- a/src/client/layout/layout_view.cpp
+++ b/src/client/layout/layout_view.cpp
@@ -48,7 +48,7 @@ namespace client_layout
   {
   }
 
-  bool LayoutView::computeLayout(const ConstraintSpace &avilableSpace)
+  bool LayoutView::computeLayout(const ConstraintSpace &availableSpace)
   {
     function<void(LayoutObject &, const LayoutObject &)> traverseChildNode =
       [&traverseChildNode](LayoutObject &object, const LayoutObject &parent)
@@ -80,8 +80,8 @@ namespace client_layout
     // TODO(yorkie): support the lifecycle `willComputeLayout`?
 
     // Use taffy to compute the layout.
-    bool r = LayoutBlockFlow::computeLayout(avilableSpace);
-    didComputeLayoutOnce(avilableSpace);
+    bool r = LayoutBlockFlow::computeLayout(availableSpace);
+    didComputeLayoutOnce(availableSpace);
 
     // Traverse the children of the view and call `didComputeLayout` for each child.
     // This lifecycle `didComputeLayout` is used to setup for the next layout computation such as setting the content
@@ -90,7 +90,7 @@ namespace client_layout
       traverseChildNode(*child, *this);
 
     // Finally, call `didComputeLayout` for the view itself.
-    didComputeLayout(avilableSpace);
+    didComputeLayout(availableSpace);
     return r;
   }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the hit-testing logic in the layout system, primarily by refactoring how hit-testable bounding boxes are computed and stored for layout boxes. The changes make the bounding box handling more robust and extensible, especially for cases involving multiple or nested boxes. Additionally, the layout lifecycle is enhanced with a new `didComputeLayout` hook, which is now called consistently after layout computation. There are also minor updates for debugging and style.

### Hit-testing and bounding box improvements

* Refactored `LayoutBox` to support multiple hit-testable bounding boxes by replacing the single `hit_testable_bounding_box_` with a vector `hit_testable_bounding_boxes_`, and updated all relevant methods and usages to operate on vectors instead of single boxes. (`src/client/layout/layout_box.cpp`, `src/client/layout/layout_box.hpp`) [[1]](diffhunk://#diff-effe5505892a7b4f5407c2c5c36634998ae72b316c479ac69faa73b34e66b54bL290-R312) [[2]](diffhunk://#diff-effe5505892a7b4f5407c2c5c36634998ae72b316c479ac69faa73b34e66b54bL401-R453) [[3]](diffhunk://#diff-a444bb65e8d0d57eea674e3eed342aba7d6cc859f94679d9344befca8fc1d09eL216-R221) [[4]](diffhunk://#diff-a444bb65e8d0d57eea674e3eed342aba7d6cc859f94679d9344befca8fc1d09eL232-R233)
* Enhanced the logic for updating and collecting hit-testable bounding boxes to avoid redundancies and ensure only meaningful boxes are tracked, skipping boxes fully contained within their parent and those with zero size. (`src/client/layout/layout_box.cpp`)
* Updated hit-testing intersection logic to iterate through all bounding boxes and return true if any box is intersected by the hit test ray. (`src/client/layout/layout_box.cpp`)

### Layout lifecycle enhancements

* Introduced a new virtual method `didComputeLayout` in `LayoutObject` and its subclasses, and ensured it is called after layout computation for all layout objects, including the view itself. (`src/client/layout/layout_object.hpp`, `src/client/layout/layout_object.cpp`, `src/client/layout/layout_box.cpp`, `src/client/layout/layout_view.cpp`, `src/client/layout/layout_box.hpp`) [[1]](diffhunk://#diff-a3564be4b10d49828a0255553126da0fcdd85b4b3407538b9873cd03c128e7ffR459) [[2]](diffhunk://#diff-562208754ab4806221bde795021f75847721dfc0a0a174dd0edd28e3cc7a7147R956-R959) [[3]](diffhunk://#diff-a444bb65e8d0d57eea674e3eed342aba7d6cc859f94679d9344befca8fc1d09eR201) [[4]](diffhunk://#diff-531b1e02744c6b3a907bcc57c123145911c09b7df66e54005e363ce1364fe29fL58-R60) [[5]](diffhunk://#diff-531b1e02744c6b3a907bcc57c123145911c09b7df66e54005e363ce1364fe29fR75-R77) [[6]](diffhunk://#diff-531b1e02744c6b3a907bcc57c123145911c09b7df66e54005e363ce1364fe29fR92-R93)
* Moved the update of hit-testable bounding boxes to the new `didComputeLayout` hook, ensuring it happens at the correct point in the layout lifecycle. (`src/client/layout/layout_box.cpp`) [[1]](diffhunk://#diff-effe5505892a7b4f5407c2c5c36634998ae72b316c479ac69faa73b34e66b54bR340-R347) [[2]](diffhunk://#diff-effe5505892a7b4f5407c2c5c36634998ae72b316c479ac69faa73b34e66b54bL343-L345)

### Minor changes

* Added a debug log statement for mouse up events on DOM elements to aid in development and debugging. (`src/client/dom/document_event_dispatcher.cpp`)
* Updated the hover background color in the simple HTML fixture. (`fixtures/html/simple.html`)
* Removed unused initialization of the old bounding box member in `LayoutBox` constructor. (`src/client/layout/layout_box.cpp`)

/cc @EndlessJour9527 